### PR TITLE
Added note for windows use, changed default filename to avoid overwriting potentially wanted originals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ $ ./thumb
 usage: thumb [-d destination] [-s size] images...
 ```
 If you don't want the full repository simply move the `thumb` executable anywhere in your `$PATH`.
+
+### Notes
+This script can be run on Windows Subsystem for Linux, you may need to invoke `bash` explicitly for it to function:
+```
+bash thumb [-d destination] [-s size] images...
+```

--- a/thumb
+++ b/thumb
@@ -34,7 +34,7 @@ declare -a MISSING_FILES
 for p in "$@"; do
     if [[ -f "$p" ]]; then
         echo Reducing "$p" to "$SIZE"
-        convert "$p" -resize "$SIZE" -background "rgba(0, 0, 0, 0)" -gravity center "$OUTPUT/$(basename ${p%.*}).png"
+        convert "$p" -resize "$SIZE" -background "rgba(0, 0, 0, 0)" -gravity center "$OUTPUT/tel_$(basename ${p%.*}).png"
     else
         # echo Image "$p" not found
         MISSING_FILES+=($p)


### PR DESCRIPTION
Two minor changes:

1. Add a little information to the README explaining how to use the script on Windows
2. changed the default output to preface new images with `tel_` in case `$output` is not set to keep from accidentally overwriting and destroying the original files. 